### PR TITLE
Add divmod

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,77 +2,20 @@
 
 
 # WARNING: This repository is mostly a PoC, for full py2nim transpiler see [py2nim](https://github.com/metacraft-labs/py2nim)
+Nimpylib is a collection of python-like operators and functions. It can help you to translate your Python program to Nim.
 
-Nimpylib is a collection of python-like operators and functions (syntax sugar).
-It can help you to translate your Python program to Nim.
+Also there's simple ```class``` macro similar to Python class (but without inheritance)
 
-Also there's simple ```class``` macro similar to Python class (but without inheritance).
+Nimpylib heavily relies on Nim generics, converters, operator overloading, and even on concepts
 
-Nimpylib heavily relies on Nim generics, converters, operator overloading, and even on concepts.
-
-
-# Use
-
-Example: Python-like `range`, `print`, `class`, `def` and more:
-
+Example: Python-like range and print procedures:
 ```nim
->>> import pylib
->>> include pylib/range  # It's necessary to include range module separately
->>>
->>> let data = range(0, -10, -2)
->>> echo data
-@[0, -2, -4, -6, -8]
->>>
->>> for i in range(10):
-      print(i, endl=" ")
-0 1 2 3 4 5 6 7 8 9
->>>
->>> echo capwords("hello world capitalized")  # Like Pythons string.capwords()
-Hello World Capitalized
->>> echo "a".center(9)
-         a        
->>>
->>> print("Hello,", input("What is your name? "), endl="\n~~~\n")
->>>
->>> discard str("This is a string.")  # string.
->>> discard int(42)                   # integer.
->>> discard float(1.0)                # float.
->>>
->>> type Example = ref object
-      start: int
-      stop: int
-      step: int
+import pylib
+include pylib/range  # It's neccessary to include range module separately
+let data = range(0, -10, -2)
+echo data # @[0, -2, -4, -6, -8]
+for i in range(10):
+  print(i, endl = " ")  # 0 1 2 3 4 5 6 7 8 9
 
->>>
->>> class Example(object):
-      """Example class with Python-ish Nim syntax!."""
-
-      def init(self, start, stop, step=1):
-        self.start = start
-        self.stop = stop
-        self.step = step
-
-      def stopit(self, argument):
-        """Example function with Python-ish Nim syntax."""
-        self.stop = argument
-        return self.stop
-
->>>
+print("Hello,", input("What is your name? "), endl="\n~~~\n")
 ```
-
-- [Check the Examples folder for more examples.](https://github.com/Yardanico/nimpylib/tree/master/examples)
-
-
-# Install
-
-```
-nimble install pylib
-```
-
-- Uninstall `nimble uninstall pylib`.
-
-
-# Requisites
-
-- [Nim](https://nim-lang.org)
-- [Nimble](https://github.com/nim-lang/nimble#installation)

--- a/README.md
+++ b/README.md
@@ -2,20 +2,77 @@
 
 
 # WARNING: This repository is mostly a PoC, for full py2nim transpiler see [py2nim](https://github.com/metacraft-labs/py2nim)
-Nimpylib is a collection of python-like operators and functions. It can help you to translate your Python program to Nim. 
 
-Also there's simple ```class``` macro similar to Python class (but without inheritance)
+Nimpylib is a collection of python-like operators and functions (syntax sugar).
+It can help you to translate your Python program to Nim.
 
-Nimpylib heavily relies on Nim generics, converters, operator overloading, and even on concepts
+Also there's simple ```class``` macro similar to Python class (but without inheritance).
 
-Example: Python-like range and print procedures:
+Nimpylib heavily relies on Nim generics, converters, operator overloading, and even on concepts.
+
+
+# Use
+
+Example: Python-like `range`, `print`, `class`, `def` and more:
+
 ```nim
-import pylib
-include pylib/range  # It's neccessary to include range module separately
-let data = range(0, -10, -2)
-echo data # @[0, -2, -4, -6, -8]
-for i in range(10):
-  print(i, endl = " ")  # 0 1 2 3 4 5 6 7 8 9
+>>> import pylib
+>>> include pylib/range  # It's necessary to include range module separately
+>>>
+>>> let data = range(0, -10, -2)
+>>> echo data
+@[0, -2, -4, -6, -8]
+>>>
+>>> for i in range(10):
+      print(i, endl=" ")
+0 1 2 3 4 5 6 7 8 9
+>>>
+>>> echo capwords("hello world capitalized")  # Like Pythons string.capwords()
+Hello World Capitalized
+>>> echo "a".center(9)
+         a        
+>>>
+>>> print("Hello,", input("What is your name? "), endl="\n~~~\n")
+>>>
+>>> discard str("This is a string.")  # string.
+>>> discard int(42)                   # integer.
+>>> discard float(1.0)                # float.
+>>>
+>>> type Example = ref object
+      start: int
+      stop: int
+      step: int
 
-print("Hello,", input("What is your name? "), endl="\n~~~\n")
+>>>
+>>> class Example(object):
+      """Example class with Python-ish Nim syntax!."""
+
+      def init(self, start, stop, step=1):
+        self.start = start
+        self.stop = stop
+        self.step = step
+
+      def stopit(self, argument):
+        """Example function with Python-ish Nim syntax."""
+        self.stop = argument
+        return self.stop
+
+>>>
 ```
+
+- [Check the Examples folder for more examples.](https://github.com/Yardanico/nimpylib/tree/master/examples)
+
+
+# Install
+
+```
+nimble install pylib
+```
+
+- Uninstall `nimble uninstall pylib`.
+
+
+# Requisites
+
+- [Nim](https://nim-lang.org)
+- [Nimble](https://github.com/nim-lang/nimble#installation)

--- a/src/pylib.nim
+++ b/src/pylib.nim
@@ -5,16 +5,16 @@ import pylib/[
   pyrandom]
 export class, print, types, ops, strops, pystring, tonim, pyrandom
 
-type 
+type
   Iterable*[T] = concept x
     for value in x:
       value is T
-  
+
 const
   True* = true
   False* = false
 
-converter bool*[T](arg: T): bool = 
+converter bool*[T](arg: T): bool =
   ## Converts argument to boolean
   ## checking python-like truthiness
   # If we have len proc for this object
@@ -32,22 +32,29 @@ converter bool*[T](arg: T): bool =
 
 converter toStr[T](arg: T): string = $arg
 
-proc input*(prompt = ""): string = 
+proc input*(prompt = ""): string =
   ## Python-like input procedure
   if prompt.len > 0:
     stdout.write(prompt)
   stdin.readLine()
 
-proc all*[T](iter: Iterable[T]): bool = 
+proc all*[T](iter: Iterable[T]): bool =
   ## Checks if all values in iterable are truthy
   result = true
   for element in iter:
     if not bool(element):
       return false
 
-proc any*[T](iter: Iterable[T]): bool = 
+proc any*[T](iter: Iterable[T]): bool =
   ## Checks if at least one value in iterable is truthy
   result = false
   for element in iter:
     if bool(element):
       return true
+
+# Mimics Pythons divmod().
+proc divmod*(a: int, b: int):     array[0..1, int]   = [int(a / b), int(a mod b)]
+proc divmod*(a: int8, b: int8):   array[0..1, int8]  = [int8(a / b), int8(a mod b)]
+proc divmod*(a: int16, b: int16): array[0..1, int16] = [int16(a / b), int16(a mod b)]
+proc divmod*(a: int32, b: int32): array[0..1, int32] = [int32(a / b), int32(a mod b)]
+proc divmod*(a: int64, b: int64): array[0..1, int64] = [int64(a / b), int64(a mod b)]


### PR DESCRIPTION
- Add mimic proc for Pythons `divmod(int, int) -> (int, int)` (on Nim those are separated ops).

It helps save some repetitive lines, eg:
```nim
(kilo, bite) = divmod(integer_bytes, int64(1_024))
(mega, kilo) = divmod(kilo, int64(1_024))
(giga, mega) = divmod(mega, int64(1_024))
(tera, giga) = divmod(giga, int64(1_024))
(peta, tera) = divmod(tera, int64(1_024))
(exa, peta) = divmod(peta, int64(1_024))
(zetta, exa) = divmod(exa, int64(1_024))
(yotta, zetta) = divmod(zetta, int64(1_024))
```
:cat: 