### PR TITLE
Add Python 3.9 new feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ nimble install pylib
 - [x] `True` / `False`
 - [x] `pass` also can take and discard any arguments
 - [x] `:=` Walrus Operator
+- [x] `{"a": 1} | {"b": 2}` Dict merge operator
 - [x] Python-like OOP class with methods and DocStrings (without inheritance)
 - [x] `abs()`
 - [x] `all()`

--- a/src/pylib.nim
+++ b/src/pylib.nim
@@ -6,9 +6,10 @@ export math, tables
 import pylib/[
   class, print, types, ops, unpack,
   string/strops, string/pystring,
-  tonim, pyrandom, xrange
+  tonim, pyrandom, xrange, pytables
 ]
-export class, print, types, ops, unpack, strops, pystring, tonim, pyrandom, xrange
+export
+  class, print, types, ops, unpack, strops, pystring, tonim, pyrandom, xrange, pytables
 
 when not defined(pylibNoLenient):
   {.warning: "'lenientops' module was imported automatically. Compile with -d:pylibNoLenient to disable it if you wish to do int->float conversions yourself".}

--- a/src/pylib/pytables.nim
+++ b/src/pylib/pytables.nim
@@ -1,0 +1,22 @@
+import tables
+
+type TableLike* = Table or OrderedTable or CountTable
+
+func `|`*[A, B: TableLike](a: A, b: B): A =
+  ## Mimic Python 3.9+ merge dicts operator `print({"a":1} | {"b":2})`,
+  ## `b` is merged into `a` like Python, without duplicate keys.
+  runnableExamples:
+    import tables
+    let a = {"a": "0", "b": "1"}.toTable
+    let b = {"c": "2", "b": "1"}.toTable
+    doAssert a | b == {"b": "1", "c": "2", "a": "0"}.toTable
+    let x = {"a": "0", "b": "1"}.toOrderedTable
+    let y = {"c": "2", "b": "1"}.toOrderedTable
+    doAssert x | y == {"a": "0", "b": "1", "c": "2"}.toOrderedTable
+    let z = {"a": "0", "b": "1"}.toCountTable
+    let v = {"c": "2", "b": "1"}.toCountTable
+    doAssert z | v  == {"a": "0", "b": "1", "c": "2"}.toCountTable
+  for key, val in a.pairs:
+    if not result.hasKey key: result[key] = val
+  for key, val in b.pairs:
+    if not result.hasKey key: result[key] = val


### PR DESCRIPTION
`{"a": 1} | {"b": 2}` is syntax sugar for `{ **foo, **bar }` on Python.