### PR TITLE
Improve pytables; bump version

### DIFF
--- a/pylib.nimble
+++ b/pylib.nimble
@@ -1,4 +1,4 @@
-version       = "0.2.1"
+version       = "0.3.0"
 author        = "Danil Yarantsev (Yardanico), Juan Carlos (juancarlospaco)"
 description   = "Nim library with python-like functions and operators"
 license       = "MIT"
@@ -9,3 +9,5 @@ requires "nim >= 1.2.0"
 
 task test, "Runs the test suite":
   exec "nim c -r tests/tester"
+  # Test all runnableExamples
+  exec "nim doc --project src/pylib.nim"

--- a/src/pylib.nim
+++ b/src/pylib.nim
@@ -1,8 +1,11 @@
 when defined(nimHasStrictFuncs):
   {.experimental: "strictFuncs".}
 
-import strutils, math, macros, unicode, tables, strformat, times, json
+import std / [
+  strutils, math, macros, unicode, tables, strformat, times, json
+]
 export math, tables
+
 import pylib/[
   class, print, types, ops, unpack,
   string/strops, string/pystring,

--- a/src/pylib/pytables.nim
+++ b/src/pylib/pytables.nim
@@ -1,22 +1,62 @@
 import tables
 
-type TableLike* = Table or OrderedTable or CountTable
+type 
+  TableLikeObj* = Table or OrderedTable or CountTable
+  TableLikeRef* = TableRef or OrderedTableRef or CountTableRef
+  TableLike* = TableLikeObj or TableLikeRef
 
 func `|`*[A, B: TableLike](a: A, b: B): A =
-  ## Mimic Python 3.9+ merge dicts operator `print({"a":1} | {"b":2})`,
-  ## `b` is merged into `a` like Python, without duplicate keys.
+  ## Python-like merge dict operator `print({"a":1} | {"b":2})`,
+  ## a new dict is created from `a` and `b`, keys in the second 
+  ## operand override keys in the first operand 
   runnableExamples:
     import tables
-    let a = {"a": "0", "b": "1"}.toTable
-    let b = {"c": "2", "b": "1"}.toTable
-    doAssert a | b == {"b": "1", "c": "2", "a": "0"}.toTable
+
+    let d = {"spam": "1", "eggs": "2", "cheese": "3"}.toTable
+    let e = {"cheese": "cheddar", "aardvark": "Ethel"}.toTable
+    doAssert d | e == {"eggs": "2", "spam": "1", "cheese": "cheddar", "aardvark": "Ethel"}.toTable
+    doAssert e | d == {"eggs": "2", "spam": "1", "cheese": "3", "aardvark": "Ethel"}.toTable
+
     let x = {"a": "0", "b": "1"}.toOrderedTable
     let y = {"c": "2", "b": "1"}.toOrderedTable
     doAssert x | y == {"a": "0", "b": "1", "c": "2"}.toOrderedTable
+
     let z = {"a": "0", "b": "1"}.toCountTable
     let v = {"c": "2", "b": "1"}.toCountTable
     doAssert z | v  == {"a": "0", "b": "1", "c": "2"}.toCountTable
+  
   for key, val in a.pairs:
-    if not result.hasKey key: result[key] = val
+    result[key] = val
+  
   for key, val in b.pairs:
-    if not result.hasKey key: result[key] = val
+    result[key] = val
+
+# TableRef and similar don't need a "var" to be modified
+proc `|=`*[A: TableLikeRef, B: TableLike](a: A, b: B) = 
+  ## Python-like in-place dict update operator.
+  ## `b` is added into `a`, keys in `b` override same keys from `a`
+  runnableExamples:
+    import tables
+
+    let d = {"spam": "1", "eggs": "2", "cheese": "3"}.newTable
+    let e = {"cheese": "cheddar", "aardvark": "Ethel"}.newTable
+    d |= e
+    doAssert d == {"spam": "1", "eggs": "2", "aardvark": "Ethel", "cheese": "cheddar"}.newTable
+  
+  for key, val in b.pairs:
+    a[key] = val
+
+# Table and similar however need it
+func `|=`*[A: TableLikeObj, B: TableLike](a: var A, b: B) = 
+  ## Python-like in-place dict update operator.
+  ## `b` is added into `a`, keys in `b` override same keys from `a`
+  runnableExamples:
+    import tables
+
+    var d = {"spam": "1", "eggs": "2", "cheese": "3"}.toTable
+    let e = {"cheese": "cheddar", "aardvark": "Ethel"}.newTable
+    d |= e
+    doAssert d == {"spam": "1", "eggs": "2", "aardvark": "Ethel", "cheese": "cheddar"}.toTable
+
+  for key, val in b.pairs:
+    a[key] = val


### PR DESCRIPTION
@juancarlospaco added two |= overloads for in-place modification and fixed your | a bit - it didn't have the same order as the Python version before