### PR TITLE
Change list parameter of `join` to type `openArray[T]` instead of `openArray[untyped]`

### DIFF
--- a/src/pylib/string/pystring.nim
+++ b/src/pylib/string/pystring.nim
@@ -26,7 +26,7 @@ func rindex*(a: string, b: StringLike, start = 0, last = 0): int =
 
 template isspace*(a: StringLike): bool = unicode.isSpace($a)
 
-template join*(sep: StringLike, a: openArray[untyped]): string =
+template join*[T](sep: StringLike, a: openArray[T]): string =
   ## Mimics Python join() -> string
   a.join($sep)
 


### PR DESCRIPTION
`openArray[untyped]` is not normally a valid type, this reduces the risk of interacting with compiler bugs.